### PR TITLE
Remove stderr/stdout from delete-*-password calls ([#11])

### DIFF
--- a/lib/security/password.rb
+++ b/lib/security/password.rb
@@ -76,7 +76,7 @@ module Security
       end
 
       def delete(options)
-        system "security delete-generic-password #{flags_for_options(options)} 2>&1 >/dev/null"
+        system "security delete-generic-password #{flags_for_options(options)} >& /dev/null"
       end
 
       private
@@ -95,7 +95,6 @@ module Security
         options[:a] = account
         options[:s] = server
         options[:w] = password
-
         system "security add-internet-password #{flags_for_options(options)}"
       end
 
@@ -104,7 +103,7 @@ module Security
       end
 
       def delete(options)
-        system "security delete-internet-password #{flags_for_options(options)} 2>&1 >/dev/null"
+        system "security delete-internet-password #{flags_for_options(options)} >&/dev/null"
       end
 
       private

--- a/lib/security/password.rb
+++ b/lib/security/password.rb
@@ -76,7 +76,7 @@ module Security
       end
 
       def delete(options)
-        system "security delete-generic-password #{flags_for_options(options)} 2>/dev/null"
+        system "security delete-generic-password #{flags_for_options(options)} 2>&1 >/dev/null"
       end
 
       private
@@ -104,7 +104,7 @@ module Security
       end
 
       def delete(options)
-        system "security delete-internet-password #{flags_for_options(options)} 2>/dev/null"
+        system "security delete-internet-password #{flags_for_options(options)} 2>&1 >/dev/null"
       end
 
       private

--- a/lib/security/password.rb
+++ b/lib/security/password.rb
@@ -76,7 +76,7 @@ module Security
       end
 
       def delete(options)
-        system "security delete-generic-password #{flags_for_options(options)}"
+        system "security delete-generic-password #{flags_for_options(options)} 2>/dev/null"
       end
 
       private
@@ -104,7 +104,7 @@ module Security
       end
 
       def delete(options)
-        system "security delete-internet-password #{flags_for_options(options)}"
+        system "security delete-internet-password #{flags_for_options(options)} 2>/dev/null"
       end
 
       private

--- a/lib/security/password.rb
+++ b/lib/security/password.rb
@@ -51,7 +51,7 @@ module Security
         flags[:G] ||= flags.delete(:value)
         flags[:j] ||= flags.delete(:comment)
 
-        flags.delete_if { |_k, v| v.nil? }.collect { |k, v| "-#{k} #{v.shellescape}".strip }.join(' ')
+        flags.compact.collect { |k, v| "-#{k} #{v.shellescape}".strip }.join(' ')
       end
 
       def decode_hex_blob(string)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,5 @@ end
 
 require_relative '../lib/security'
 
-# rubocop:disable Style/MixinUsage
+# rubocop:disable-next Style/MixinUsage
 include Security
-# rubocop:enable Style/MixinUsage


### PR DESCRIPTION
This change  to solve #11. It will hide a bit of information, but users should really use `$?` to inquire about the various calls anyway and not depend on stdout/stderr output. The library is in version < 1.0 so I expect it is OK to break this "feature".

When it comes to error handling, output control etc, the library should be overhauled anyway. See fastlane/fastlane#11637.

---

fixes: #11 



