### PR TITLE
Report security failures instead of hiding them

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,6 @@ Metrics/PerceivedComplexity:
   Enabled: false
 Lint/AmbiguousBlockAssociation:
   Enabled: false
+Naming/PredicateMethod:
+  # The command methods report success like Kernel#system, which they replace.
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -14,10 +14,52 @@
 ```ruby
 require 'security'
 
-Security::Keychain::default_keychain.filename #=> "/Users/jappleseed/Library/Keychains/login.keychain"
+Security::Keychain.default_keychain.filename #=> "/Users/jappleseed/Library/Keychains/login.keychain-db"
 
-Security::InternetPassword.find(server: "itunesconnect.apple.com").password #=> "p4ssw0rd"
+item = Security::InternetPassword.find(server: "itunesconnect.apple.com")
+item&.password #=> "p4ssw0rd"
 ```
+
+## Errors
+
+The `security` command line tool reports failures through its exit status, and
+this library distinguishes the two cases a caller needs to tell apart:
+
+- **Nothing matched.** `find` returns `nil`. The keychain answered, and it holds
+  no such item.
+- **The question could not be answered.** `find` raises `Security::Error`,
+  carrying the tool's exit `status` and its `output`. A locked keychain, a
+  keychain this process is not allowed to read, or a malformed request all
+  land here.
+
+```ruby
+begin
+  item = Security::InternetPassword.find(server: "itunesconnect.apple.com")
+rescue Security::Error => e
+  warn "could not read the keychain: #{e.message}"
+  item = nil
+end
+```
+
+`Keychain.list`, `Keychain.default_keychain` and `Keychain.login_keychain`
+raise `Security::Error` on failure in the same way.
+
+The methods that change the keychain — `add`, `delete`, and the `Keychain`
+instance methods — return `true` or `false` and print what the tool reported,
+the way `Kernel#system` does.
+
+### Upgrading from 0.2
+
+`find` used to detect failure by looking for a `security: ` prefix in the
+output. Anything else — an ACL error, which prints nothing at all, or a
+malformed request, which prints a usage banner — fell through and produced a
+`Password` with no keychain, no attributes and a `nil` password, which a caller
+could not tell from a real hit. Failures that did carry that prefix returned
+`nil`, indistinguishable from an item that was simply absent.
+
+Both now raise `Security::Error`. Callers that treat `nil` as "not in the
+keychain, fall back" should rescue it, as above, rather than let a locked
+keychain look like an empty one.
 
 ## License
 

--- a/lib/security.rb
+++ b/lib/security.rb
@@ -2,6 +2,7 @@
 
 require 'security/version'
 require 'security/error'
+require 'security/command'
 require 'security/keychain'
 require 'security/certificate'
 require 'security/password'

--- a/lib/security.rb
+++ b/lib/security.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'security/version'
+require 'security/error'
 require 'security/keychain'
 require 'security/certificate'
 require 'security/password'

--- a/lib/security/command.rb
+++ b/lib/security/command.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+module Security
+  # :nodoc:
+  module Command
+    # :nodoc:
+    Result = Struct.new(:stdout, :stderr, :status) do
+      def success?
+        status.success?
+      end
+
+      def exitstatus
+        status.exitstatus
+      end
+
+      # `security` splits what it has to say across both streams: find-*-password
+      # prints the attributes on stdout and the password on stderr.
+      def output
+        stdout + stderr
+      end
+    end
+
+    module_function
+
+    # Runs a `security` subcommand and captures what it produced.
+    def run(command)
+      Result.new(*Open3.capture3(command))
+    end
+
+    # Runs a `security` subcommand and lets the caller see what it said. The
+    # tool reports on stderr whether or not it succeeded: show-keychain-info
+    # prints its result there on exit 0.
+    def relay(command)
+      result = run(command)
+      warn result.stderr.chomp unless result.stderr.empty?
+
+      result
+    end
+  end
+end

--- a/lib/security/command.rb
+++ b/lib/security/command.rb
@@ -5,6 +5,7 @@ require 'open3'
 module Security
   # :nodoc:
   module Command
+    # TODO: replace with Data.define once Ruby 3.1 support is dropped.
     # :nodoc:
     Result = Struct.new(:stdout, :stderr, :status) do
       def success?

--- a/lib/security/error.rb
+++ b/lib/security/error.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Security
+  # :nodoc:
+  class Error < StandardError
+    attr_reader :status, :output
+
+    def initialize(status, output)
+      @status = status
+      @output = output
+
+      details = output.strip
+      super(details.empty? ? "`security` exited with status #{status}" : "#{details} (status #{status})")
+    end
+  end
+end

--- a/lib/security/keychain.rb
+++ b/lib/security/keychain.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'open3'
 require 'shellwords'
 
 module Security
@@ -37,7 +38,7 @@ module Security
       def list(domain = :user)
         raise ArgumentError, "Invalid domain #{domain}, expected one of: #{DOMAINS}" unless DOMAINS.include?(domain)
 
-        keychains_from_output(`security list-keychains -d #{domain}`)
+        keychains_from_command("security list-keychains -d #{domain}")
       end
 
       def lock
@@ -49,14 +50,21 @@ module Security
       end
 
       def default_keychain
-        keychains_from_output(`security default-keychain`).first
+        keychains_from_command('security default-keychain').first
       end
 
       def login_keychain
-        keychains_from_output(`security login-keychain`).first
+        keychains_from_command('security login-keychain').first
       end
 
       private
+
+      def keychains_from_command(command)
+        out, err, status = Open3.capture3(command)
+        raise Error.new(status.exitstatus, err) unless status.success?
+
+        keychains_from_output(out)
+      end
 
       def keychains_from_output(output)
         output.split("\n").collect { |line| new(line.strip.gsub(/^"|"$/, '')) }

--- a/lib/security/keychain.rb
+++ b/lib/security/keychain.rb
@@ -35,7 +35,7 @@ module Security
       end
 
       def list(domain = :user)
-        raise ArgumentError "Invalid domain #{domain}, expected one of: #{DOMAINS}" unless DOMAINS.include?(domain)
+        raise ArgumentError, "Invalid domain #{domain}, expected one of: #{DOMAINS}" unless DOMAINS.include?(domain)
 
         keychains_from_output(`security list-keychains -d #{domain}`)
       end

--- a/lib/security/keychain.rb
+++ b/lib/security/keychain.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'open3'
 require 'shellwords'
 
 module Security
@@ -15,19 +14,19 @@ module Security
     end
 
     def info
-      system %(security show-keychain-info #{@filename.shellescape})
+      Command.relay(%(security show-keychain-info #{@filename.shellescape})).success?
     end
 
     def lock
-      system %(security lock-keychain #{@filename.shellescape})
+      Command.relay(%(security lock-keychain #{@filename.shellescape})).success?
     end
 
     def unlock(password)
-      system %(security unlock-keychain -p #{password.shellescape} #{@filename.shellescape})
+      Command.relay(%(security unlock-keychain -p #{password.shellescape} #{@filename.shellescape})).success?
     end
 
     def delete
-      system %(security delete-keychain #{@filename.shellescape})
+      Command.relay(%(security delete-keychain #{@filename.shellescape})).success?
     end
 
     class << self
@@ -42,11 +41,11 @@ module Security
       end
 
       def lock
-        system %(security lock-keychain -a)
+        Command.relay(%(security lock-keychain -a)).success?
       end
 
       def unlock(password)
-        system %(security unlock-keychain -p #{password.shellescape})
+        Command.relay(%(security unlock-keychain -p #{password.shellescape})).success?
       end
 
       def default_keychain
@@ -60,10 +59,10 @@ module Security
       private
 
       def keychains_from_command(command)
-        out, err, status = Open3.capture3(command)
-        raise Error.new(status.exitstatus, err) unless status.success?
+        result = Command.run(command)
+        raise Error.new(result.exitstatus, result.stderr) unless result.success?
 
-        keychains_from_output(out)
+        keychains_from_output(result.stdout)
       end
 
       def keychains_from_output(output)

--- a/lib/security/password.rb
+++ b/lib/security/password.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
+require 'open3'
 require 'shellwords'
 
 module Security
   # :nodoc:
   class Password
+    # `security` reports a missing item with this exit status. Every other
+    # non-zero status is a failure the caller needs to know about.
+    ITEM_NOT_FOUND = 44
+
     attr_reader :keychain, :attributes, :password
 
     private_class_method :new
@@ -18,9 +23,16 @@ module Security
     class << self
       private
 
-      def password_from_output(output)
-        return nil if output.match?(/^security: /)
+      def password_from_command(command)
+        out, err, status = Open3.capture3(command)
+        return nil if status.exitstatus == ITEM_NOT_FOUND
+        raise Error.new(status.exitstatus, err) unless status.success?
 
+        # `security -g` prints the attributes on stdout and the password on stderr.
+        password_from_output(out + err)
+      end
+
+      def password_from_output(output)
         keychain = nil
         attributes = {}
         password = nil
@@ -72,7 +84,7 @@ module Security
       end
 
       def find(options)
-        password_from_output(`security 2>&1 find-generic-password -g #{flags_for_options(options)}`)
+        password_from_command("security find-generic-password -g #{flags_for_options(options)}")
       end
 
       def delete(options)
@@ -99,7 +111,7 @@ module Security
       end
 
       def find(options)
-        password_from_output(`security 2>&1 find-internet-password -g #{flags_for_options(options)}`)
+        password_from_command("security find-internet-password -g #{flags_for_options(options)}")
       end
 
       def delete(options)

--- a/lib/security/password.rb
+++ b/lib/security/password.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'open3'
 require 'shellwords'
 
 module Security
@@ -24,12 +23,11 @@ module Security
       private
 
       def password_from_command(command)
-        out, err, status = Open3.capture3(command)
-        return nil if status.exitstatus == ITEM_NOT_FOUND
-        raise Error.new(status.exitstatus, err) unless status.success?
+        result = Command.run(command)
+        return nil if result.exitstatus == ITEM_NOT_FOUND
+        raise Error.new(result.exitstatus, result.stderr) unless result.success?
 
-        # `security -g` prints the attributes on stdout and the password on stderr.
-        password_from_output(out + err)
+        password_from_output(result.output)
       end
 
       def password_from_output(output)
@@ -80,7 +78,7 @@ module Security
         options[:s] = service
         options[:w] = password
 
-        system "security add-generic-password #{flags_for_options(options)}"
+        Command.relay("security add-generic-password #{flags_for_options(options)}").success?
       end
 
       def find(options)
@@ -88,7 +86,7 @@ module Security
       end
 
       def delete(options)
-        system "security delete-generic-password #{flags_for_options(options)} >& /dev/null"
+        Command.run("security delete-generic-password #{flags_for_options(options)}").success?
       end
 
       private
@@ -107,7 +105,7 @@ module Security
         options[:a] = account
         options[:s] = server
         options[:w] = password
-        system "security add-internet-password #{flags_for_options(options)}"
+        Command.relay("security add-internet-password #{flags_for_options(options)}").success?
       end
 
       def find(options)
@@ -115,7 +113,7 @@ module Security
       end
 
       def delete(options)
-        system "security delete-internet-password #{flags_for_options(options)} >&/dev/null"
+        Command.run("security delete-internet-password #{flags_for_options(options)}").success?
       end
 
       private

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+describe Security::Command do
+  describe '.run' do
+    describe 'when the command succeeds' do
+      subject { Security::Command.run('echo out; echo err 1>&2') }
+
+      it 'should capture both streams and the status' do
+        expect(subject.stdout).to be == "out\n"
+        expect(subject.stderr).to be == "err\n"
+        expect(subject.exitstatus).to be_zero
+        expect(subject.success?).to be true
+        expect(subject.output).to be == "out\nerr\n"
+      end
+    end
+
+    describe 'when the command fails' do
+      subject { Security::Command.run('exit 3') }
+
+      it 'should report the status' do
+        expect(subject.exitstatus).to be == 3
+        expect(subject.success?).to be false
+      end
+    end
+
+    it 'should not relay what the command printed' do
+      expect { Security::Command.run('echo quiet 1>&2') }.not_to output.to_stderr
+    end
+  end
+
+  describe '.relay' do
+    it 'should relay what the command printed and return the result' do
+      result = nil
+      expect { result = Security::Command.relay('echo boom 1>&2; exit 1') }.to output("boom\n").to_stderr
+      expect(result.success?).to be false
+    end
+
+    it 'should stay silent when the command printed nothing' do
+      expect { Security::Command.relay('true') }.not_to output.to_stderr
+    end
+  end
+end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Security::Error do
+  describe '#initialize' do
+    describe 'when the command produced output' do
+      subject { Security::Error.new(2, "security: something went wrong\n") }
+
+      it 'should report the output and the status' do
+        expect(subject.status).to be == 2
+        expect(subject.output).to be == "security: something went wrong\n"
+        expect(subject.message).to be == 'security: something went wrong (status 2)'
+      end
+    end
+
+    describe 'when the command produced no output' do
+      subject { Security::Error.new(36, '') }
+
+      it 'should report the status' do
+        expect(subject.status).to be == 36
+        expect(subject.message).to be == '`security` exited with status 36'
+      end
+    end
+  end
+end

--- a/spec/keychain_spec.rb
+++ b/spec/keychain_spec.rb
@@ -95,8 +95,10 @@ describe Keychain do
     end
 
     describe 'when passing an invalid domain' do
-      it 'should raise an error' do
-        expect { Keychain.list(:invalid) }.to raise_error(NoMethodError) # FIXME
+      it 'should raise an error naming the valid domains' do
+        expect { Keychain.list(:invalid) }.to raise_error(
+          ArgumentError, 'Invalid domain invalid, expected one of: [:user, :system, :common, :dynamic]'
+        )
       end
     end
   end

--- a/spec/keychain_spec.rb
+++ b/spec/keychain_spec.rb
@@ -101,5 +101,17 @@ describe Keychain do
         )
       end
     end
+
+    describe 'when the security command fails' do
+      it 'should raise an error carrying the status and the output' do
+        status = instance_double(Process::Status, success?: false, exitstatus: 1)
+        allow(Open3).to receive(:capture3).and_return(['', "security: unknown command\n", status])
+
+        expect { Keychain.list }.to raise_error(Security::Error) do |error|
+          expect(error.status).to be == 1
+          expect(error.message).to match(/unknown command/)
+        end
+      end
+    end
   end
 end

--- a/spec/keychain_spec.rb
+++ b/spec/keychain_spec.rb
@@ -3,6 +3,8 @@
 require 'tempfile'
 
 describe Keychain do
+  let(:succeeded) { Security::Command.run('true') }
+
   describe '#login_keychain' do
     subject { Keychain.login_keychain }
 
@@ -22,14 +24,16 @@ describe Keychain do
 
   describe '#lock' do
     it 'should lock all keychains' do
-      expect(Keychain).to receive(:system).with('security lock-keychain -a')
+      expect(Security::Command).to receive(:relay)
+        .with('security lock-keychain -a').and_return(succeeded)
       Keychain.lock
     end
   end
 
   describe '#unlock' do
     it 'should unlock keychains with the given password' do
-      expect(Keychain).to receive(:system).with('security unlock-keychain -p p4ssw0rd')
+      expect(Security::Command).to receive(:relay)
+        .with('security unlock-keychain -p p4ssw0rd').and_return(succeeded)
       Keychain.unlock('p4ssw0rd')
     end
   end
@@ -39,28 +43,32 @@ describe Keychain do
 
     describe '#info' do
       it 'should show keychain info' do
-        expect(subject).to receive(:system).with('security show-keychain-info test.keychain-db')
+        expect(Security::Command).to receive(:relay)
+          .with('security show-keychain-info test.keychain-db').and_return(succeeded)
         subject.info
       end
     end
 
     describe '#lock' do
       it 'should lock the keychain' do
-        expect(subject).to receive(:system).with('security lock-keychain test.keychain-db')
+        expect(Security::Command).to receive(:relay)
+          .with('security lock-keychain test.keychain-db').and_return(succeeded)
         subject.lock
       end
     end
 
     describe '#unlock' do
       it 'should unlock the keychain with the given password' do
-        expect(subject).to receive(:system).with('security unlock-keychain -p p4ssw0rd test.keychain-db')
+        expect(Security::Command).to receive(:relay)
+          .with('security unlock-keychain -p p4ssw0rd test.keychain-db').and_return(succeeded)
         subject.unlock('p4ssw0rd')
       end
     end
 
     describe '#delete' do
       it 'should delete the keychain' do
-        expect(subject).to receive(:system).with('security delete-keychain test.keychain-db')
+        expect(Security::Command).to receive(:relay)
+          .with('security delete-keychain test.keychain-db').and_return(succeeded)
         subject.delete
       end
     end

--- a/spec/password_spec.rb
+++ b/spec/password_spec.rb
@@ -26,6 +26,23 @@ describe GenericPassword do
       expect(entry.password).to be == password
     end
   end
+
+  describe '#find' do
+    describe 'when no matching item exists' do
+      it 'should return nil' do
+        expect(GenericPassword.find(service: 'com.example.no-such-service')).to be_nil
+      end
+    end
+
+    describe 'when the security command fails' do
+      it 'should raise an error carrying the status and the output' do
+        expect { GenericPassword.find(Z: 'bogus') }.to raise_error(Security::Error) do |error|
+          expect(error.status).to be == 2
+          expect(error.message).to match(/illegal option/)
+        end
+      end
+    end
+  end
 end
 
 describe InternetPassword do


### PR DESCRIPTION
Fixes #5.

`find` detected failure by matching `/^security: /` on the output and never
checked the exit status. Failures that print nothing fell through and returned a
`Password` with no keychain, attributes or password — indistinguishable from a
hit. Failures that did carry the prefix returned `nil` — indistinguishable from
an absent item.

Every `security` call now runs through `Security::Command`, which captures both
streams and the status. `find` returns `nil` only for status 44 (not found) and
otherwise raises `Security::Error`, carrying `status` and `output`.
`Keychain.list`, `.default_keychain` and `.login_keychain` do the same. The
mutating calls still return booleans, so their signatures are unchanged.

Also fixes a missing comma in `Keychain.list`, where `raise ArgumentError "..."`
parsed as a method call and raised `NoMethodError` instead.

### Reproducing #5

The report showed status 36 with empty output, on Sierra. It is a locked
keychain queried from a session with no window server — in a GUI session macOS
puts up an unlock dialog and the command blocks instead of failing.

    security create-keychain -p reproduce /tmp/repro.keychain-db
    security unlock-keychain -p reproduce /tmp/repro.keychain-db
    security add-generic-password -a acct -s svc -w s3cret /tmp/repro.keychain-db
    security lock-keychain /tmp/repro.keychain-db

    # headless: `launchctl managername` reports Background, not Aqua
    ssh localhost 'security find-generic-password -g -s svc /tmp/repro.keychain-db'
    # => exit 36, no output

0.1.5 turns that into `#<Security::GenericPassword @keychain=#<Security::Keychain
@filename=nil>, @attributes={}, @password=nil>` — the object in the report. This
branch raises `Security::Error` with `status` 36.

### Breaking

Callers treating `nil` as "not in the keychain" should rescue `Security::Error`,
or a locked keychain reads as an empty one. See the README's Errors section.
Wants a 0.3.0, which will require a fastlane PR. 

https://github.com/lacostej/fastlane/tree/chore/security_gem_integration_test in the works.