### PR TITLE
fix: report a missing `security` instead of raising Errno::ENOENT

### DIFF
--- a/lib/security/command.rb
+++ b/lib/security/command.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'English'
 require 'open3'
 
 module Security
@@ -9,11 +10,11 @@ module Security
     # :nodoc:
     Result = Struct.new(:stdout, :stderr, :status) do
       def success?
-        status.success?
+        !status.nil? && status.success?
       end
 
       def exitstatus
-        status.exitstatus
+        status&.exitstatus
       end
 
       # `security` splits what it has to say across both streams: find-*-password
@@ -25,9 +26,17 @@ module Security
 
     module_function
 
-    # Runs a `security` subcommand and captures what it produced.
+    # Runs a `security` subcommand and captures what it produced. A missing
+    # `security` is a failed result rather than an exception: the tool is only
+    # present on macOS, and callers elsewhere should see the same failure they
+    # would get from a keychain that could not answer.
     def run(command)
       Result.new(*Open3.capture3(command))
+    rescue Errno::ENOENT => e
+      # Nothing ran, but the child Ruby forked exited 127 before exec, which is
+      # what a shell reports for a missing command, and what this library
+      # produced while it still went through one.
+      Result.new('', "#{e.message}\n", $CHILD_STATUS)
     end
 
     # Runs a `security` subcommand and lets the caller see what it said. The

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -28,6 +28,28 @@ describe Security::Command do
     end
   end
 
+  describe '.run when the command does not exist' do
+    subject { Security::Command.run('security-does-not-exist') }
+
+    it 'should report a failure rather than raising' do
+      expect(subject.success?).to be false
+      expect(subject.stderr).to match(/No such file or directory/)
+    end
+
+    it 'should report the status a shell gives a missing command' do
+      expect(subject.exitstatus).to be == 127
+    end
+  end
+
+  describe 'a result for a command that never ran' do
+    subject { Security::Command::Result.new('', '', nil) }
+
+    it 'should not be a success' do
+      expect(subject.success?).to be false
+      expect(subject.exitstatus).to be_nil
+    end
+  end
+
   describe '.relay' do
     it 'should relay what the command printed and return the result' do
       result = nil

--- a/spec/password_spec.rb
+++ b/spec/password_spec.rb
@@ -169,3 +169,41 @@ describe 'a non-default keychain' do
     end
   end
 end
+
+describe 'when `security` is not available' do
+  # Every platform other than macOS. The tool used to be reached through a
+  # shell, which reported a missing command as status 127; callers depend on
+  # seeing a failure rather than an exception escaping the library.
+  around(:example) do |example|
+    original = ENV.fetch('PATH', nil)
+    ENV['PATH'] = '/nonexistent'
+    begin
+      example.run
+    ensure
+      ENV['PATH'] = original
+    end
+  end
+
+  describe '#find' do
+    it 'should raise a Security::Error carrying the status' do
+      expect { GenericPassword.find(service: 'com.example.service') }.to raise_error(Security::Error) do |error|
+        expect(error.status).to be == 127
+        expect(error.message).to match(/No such file or directory/)
+      end
+    end
+  end
+
+  describe '#add' do
+    it 'should report failure rather than raising, relaying what went wrong' do
+      expect do
+        expect(GenericPassword.add('com.example.service', 'jappleseed', 'p4ssw0rd')).to be false
+      end.to output(/No such file or directory/).to_stderr
+    end
+  end
+
+  describe '#delete' do
+    it 'should report failure rather than raising' do
+      expect(GenericPassword.delete(service: 'com.example.service')).to be false
+    end
+  end
+end


### PR DESCRIPTION
The command string used to carry a `2>&1` redirect, so it always ran through a shell, and a missing `security` came back as exit 127 with the shell's "command not found" on stdout. Running it through Open3.capture3 without the redirect execs directly, so on a platform that has no `security` — every one but macOS — the spawn raises Errno::ENOENT, which is not a Security::Error and escapes the library. fastlane's Linux and Windows suites hit this through CredentialsManager::AccountManager#password.

Catch it and return a failed result. $? holds the status of the child Ruby forked, which exits 127 before exec, so the status reported is the one the shell gave before rather than an invented constant. find raises Security::Error as it does for any other failure, and the mutating calls report false, as Kernel#system did when it could not execute.